### PR TITLE
fix: Add librsvg2-common as dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -22,4 +22,5 @@ Depends: python3,
          python3-gi,
          libadwaita-1-0,
          gir1.2-gtk-4.0,
+         librsvg2-common,
 Description: A quick slideview Tour of all new things in Vanilla OS.


### PR DESCRIPTION
- Add `librsvg2-common` to debian/control

This I believe is already included with our standard install, but in the event it is missing, it would be beneficial to have it listed as a dependency